### PR TITLE
Add Terraform configuration for EC2 deployment and include override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,13 +16,6 @@ crash.*.log
 *.tfvars
 *.tfvars.json
 
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
 # Include override files you do wish to add to version control using negated pattern
 # !example_override.tf
 

--- a/localstack_providers_override.tf
+++ b/localstack_providers_override.tf
@@ -1,0 +1,41 @@
+# localstack_providers_override.tf
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  access_key = "test"
+  secret_key = "test"
+  region     = "us-east-1"
+  endpoints {
+    apigateway     = "http://localhost:4566"
+    cloudformation = "http://localhost:4566"
+    cloudwatch     = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    ec2            = "http://localhost:4566"
+    ecs            = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    es             = "http://localhost:4566"
+    firehose       = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    kinesis        = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    redshift       = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    s3             = "http://localhost:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    stepfunctions  = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
+}


### PR DESCRIPTION
- Added localstack_providers_override.tf to configure AWS provider with LocalStack endpoints.
- Removed override files from .gitignore to include localstack_providers_override.tf in version control.